### PR TITLE
Add support for hex and hexdump formatting of bytes types.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,13 @@
 # `typedargs`
 
+## 1.0.1
+
+- Add support for two additional formatters for `bytes` type data: hex and
+  hexdump.  These allow the creation of functions that return binary data but
+  are still usable from the command line since the binary data will be printed
+  as either hex format or a normal hex dump such as what disassemblers show
+  for memory dumps.
+
 ## 1.0.0
 
 - Drop python2 support

--- a/test/test_builtin_types.py
+++ b/test/test_builtin_types.py
@@ -125,3 +125,40 @@ def test_bytes_from_hex():
 
     assert val == val2
     assert val == bytearray(b'\xab\xcd')
+
+
+def test_bytes_hex_formatting():
+    """Make sure we can convert a bytes object to hex."""
+
+    assert type_system.format_value(b'\xab\xcd', 'bytes', 'hex') == 'abcd'
+    assert type_system.format_value(bytearray([0xab, 0xcd]), 'bytes', 'hex') == 'abcd'
+    assert type_system.format_value(b'', 'bytes', 'hex') == ''
+
+
+EXPECTED_HEXDUMP = \
+"""00000000  00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f  ................
+00000010  10 11 12 13 14 15 16 17 18 19 1a 1b 1c 1d 1e 1f  ................
+00000020  20 21 22 23 24 25 26 27 28 29 2a 2b 2c 2d 2e 2f   !"#$%&'()*+,-./
+00000030  30 31 32 33 34 35 36 37 38 39 3a 3b 3c 3d 3e 3f  0123456789:;<=>?
+00000040  40 41 42 43 44 45 46 47 48 49 4a 4b 4c 4d 4e 4f  @ABCDEFGHIJKLMNO
+00000050  50 51 52 53 54 55 56 57 58 59 5a 5b 5c 5d 5e 5f  PQRSTUVWXYZ[\\]^_
+00000060  60 61 62 63 64 65 66 67 68 69 6a 6b 6c 6d 6e 6f  `abcdefghijklmno
+00000070  70 71 72 73 74 75 76 77 78 79 7a 7b 7c 7d 7e 7f  pqrstuvwxyz{|}~.
+00000080  80 81 82 83 84 85 86 87 88 89 8a 8b 8c 8d 8e 8f  ................
+00000090  90 91 92 93 94 95 96 97 98 99 9a 9b 9c 9d 9e 9f  ................
+000000a0  a0 a1 a2 a3 a4 a5 a6 a7 a8 a9 aa ab ac ad ae af  ................
+000000b0  b0 b1 b2 b3 b4 b5 b6 b7 b8 b9 ba bb bc bd be bf  ................
+000000c0  c0 c1 c2 c3 c4 c5 c6 c7 c8 c9 ca cb cc cd ce cf  ................
+000000d0  d0 d1 d2 d3 d4 d5 d6 d7 d8 d9 da db dc dd de df  ................
+000000e0  e0 e1 e2 e3 e4 e5                                ......"""
+
+
+def test_bytes_hexdump_formatting():
+    """Make sure we can convert a bytes object to a hexdump."""
+
+    data = bytes(range(0, 230))
+
+    val = type_system.format_value(data, 'bytes', 'hexdump')
+    print(val)
+
+    assert val == EXPECTED_HEXDUMP

--- a/typedargs/types/bytes.py
+++ b/typedargs/types/bytes.py
@@ -7,21 +7,23 @@
 #Simple bytearray type
 
 import sys
-from binascii import unhexlify
+from binascii import unhexlify, hexlify
 
 
 def convert(arg, **kwargs):
     if isinstance(arg, bytearray):
         return arg
-    if isinstance(arg, str) or (isinstance(arg, bytes) and sys.version_info < (3, 0)):
+    if isinstance(arg, str):
         if len(arg) > 2 and arg.startswith("0x"):
             data = unhexlify(arg[2:])
         else:
             data = arg
 
         return bytearray(data)
+    if isinstance(arg, bytes):
+        return arg
 
-    raise TypeError("You must create a bytes object from a bytearray or a hex string")
+    raise TypeError("You must create a bytes object from bytes, bytearray or a hex string")
 
 
 def convert_binary(arg, **kwargs):
@@ -34,3 +36,44 @@ def default_formatter(arg, **kwargs):
 
 def format_repr(arg):
     return repr(arg)
+
+
+def format_hex(arg):
+    """Convert the bytes object to a hex string."""
+
+    return hexlify(arg).decode('utf-8')
+
+
+def format_hexdump(arg):
+    """Convert the bytes object to a hexdump.
+
+    The output format will be:
+
+    <offset, 4-byte>  <16-bytes of output separated by 1 space>  <16 ascii characters>
+    """
+
+    line = ''
+
+    for i in range(0, len(arg), 16):
+        if i > 0:
+            line += '\n'
+        chunk = arg[i:i + 16]
+        hex_chunk = hexlify(chunk).decode('utf-8')
+        hex_line = ' '.join(hex_chunk[j:j + 2] for j in range(0, len(hex_chunk), 2))
+
+        if len(hex_line) < (3 * 16) - 1:
+            hex_line += ' ' * (((3 * 16) - 1) - len(hex_line))
+
+        ascii_line = ''.join(_convert_to_ascii(x) for x in chunk)
+        offset_line = '%08x' % i
+
+        line += "%s  %s  %s" % (offset_line, hex_line, ascii_line)
+
+    return line
+
+
+def _convert_to_ascii(byte):
+    if byte < 32 or byte > 126:
+        return '.'
+
+    return chr(byte)

--- a/version.py
+++ b/version.py
@@ -1,1 +1,1 @@
-version = "1.0.0"
+version = "1.0.1"


### PR DESCRIPTION
This will allow the creation of `docannotate` function signatures such as:

```
@docannotate
def read_binary_data():
    """Read some binary data that cannot be easily printed as a string.

    Returns:
        bytes format-as hexdump: The binary data that we read.
    """
```

That annotation will pass back binary data to the user as `bytes` when called from python
but if invoked directly from the python shell using e.g. the `iotile` tool in CoreTools, it will print a hex representation of the binary string instead.  For functions that expect to generate a large amount of binary data, you can use `format-as hexdump` instead which will generate a nice hex dump with address offset, structured hex formatting and ascii conversion.
 
Closes #54