### PR TITLE
Fix parsing docstring if there isn't one

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,9 @@
 # `typedargs`
 
+## HEAD
+
+- Fix docstrings parsing (Issue #34) 
+
 ## 1.0.2
 
 - Fix deprecation warnings for `imp` and `collections`

--- a/test/test_docannotate.py
+++ b/test/test_docannotate.py
@@ -64,6 +64,20 @@ def test_docannotate_basic():
     assert help_text == HELPSTRING
 
 
+def test_docannotate_no_docstring():
+    """Make sure we can docannotate a function without docstring."""
+
+    @docannotate
+    def basic_func():
+        pass
+
+    try:
+        # calling returns_data triggers docstring parsing
+        _ = basic_func.metadata.returns_data()
+    except:
+        pytest.fail('Failed to decorate with docannotate a function without docstring.')
+
+
 def test_docparse():
     """Make sure we can parse a docstring."""
 
@@ -146,5 +160,3 @@ def test_parsed_doc():
 
     assert parsed1.param_info == {u'param2': ParameterInfo(type_name=u'bool', validators=[], desc=u'The basic dict parameter'),
                                   u'param1': ParameterInfo(type_name=u'integer', validators=[], desc=u'A basic parameter')}
-
-    print

--- a/typedargs/metadata.py
+++ b/typedargs/metadata.py
@@ -23,7 +23,7 @@ class AnnotatedMetadata: #pylint: disable=R0902; These instance variables are re
         self.annotated_params = {}
         self._has_self = False
 
-        docstring = func.__doc__
+        docstring = func.__doc__ if func.__doc__ else ''
 
         if inspect.isclass(func):
             # If we're annotating a class, the name of the class should be


### PR DESCRIPTION
- added a simple fix
- added test to cover the case when we try to decorate a function with missed docstring with "docannotate" decorator

Closes #34 