### PR TITLE
Fix parsing docstring with `Raises` stanza

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,9 @@
 # `typedargs`
 
+## HEAD
+
+- Fix docstrings parsing (Issue #47) 
+
 ## 1.0.2
 
 - Fix deprecation warnings for `imp` and `collections`

--- a/test/test_docannotate.py
+++ b/test/test_docannotate.py
@@ -19,6 +19,9 @@ DOCSTRING1 = """Do something.
 
         Returns:
             map(string, int): A generic struct
+
+        Raises:
+            Exception: Error description
         """
 
 HELPSTRING = """
@@ -72,6 +75,7 @@ def test_docparse():
     assert 'param1' in params
     assert 'param2' in params
     assert retinfo is not None
+    assert retinfo.type_name == 'map(string, int)'
 
 
 DOCSTRING_FORMATAS = """basic line

--- a/typedargs/doc_annotate.py
+++ b/typedargs/doc_annotate.py
@@ -33,6 +33,11 @@ def parse_docstring(doc):
             stripped = line.lstrip()
             margin = len(line) - len(stripped)
 
+            if margin == 0:
+                section = None
+                section_indent = None
+                continue
+
             if section_indent is None:
                 section_indent = margin
 


### PR DESCRIPTION
- added a fix
- updated a test for covering parsing docstring with `Raises` stanza
- updated RELEASE.md

Closes #47 