### PR TITLE
Extend docannotate `show-as` return annotation to support more options

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,6 +3,7 @@
 ## HEAD
 
 - Fix docstrings parsing (Issues #47, #34) 
+- Extend docannotate `show-as` return annotation to support more options (Issue #60)
 
 ## 1.0.2
 

--- a/test/test_docannotate.py
+++ b/test/test_docannotate.py
@@ -212,14 +212,6 @@ def test_return_value_formatter():
         return ReturnType()
 
     @docannotate
-    def func_string():
-        """
-        Returns:
-            ReturnType show-as string: an object with formatter method
-        """
-        return ReturnType()
-
-    @docannotate
     def func_noformatter():
         """
         Returns:
@@ -229,11 +221,31 @@ def test_return_value_formatter():
 
     ret_value_1 = func_1()
     ret_value_2 = func_2()
-    ret_value_string = func_string()
     ret_value_noformatter = func_noformatter()
     # import pdb; pdb.set_trace()
     assert func_1.metadata.format_returnvalue(ret_value_1) == 'foo bar'
     assert func_2.metadata.format_returnvalue(ret_value_2) == 'foo bar'
-    assert func_string.metadata.format_returnvalue(ret_value_string) == 'foo\nbar'
     with pytest.raises(ValidationError):
         func_noformatter.metadata.format_returnvalue(ret_value_noformatter)
+
+
+def test_return_value_formatter_string():
+    """Make sure we support `show-as string` return annotation."""
+
+    class ReturnType:
+        def __init__(self):
+            self.val = 'foo\nbar'
+
+        def __str__(self):
+            return self.val
+
+    @docannotate
+    def func_string():
+        """
+        Returns:
+            ReturnType show-as string: some description
+        """
+        return ReturnType()
+
+    ret_value = func_string()
+    assert func_string.metadata.format_returnvalue(ret_value) == 'foo\nbar'

--- a/typedargs/doc_parser.py
+++ b/typedargs/doc_parser.py
@@ -366,6 +366,7 @@ def parse_return(return_line, include_desc=False):
 
         if show_type == 'context':
             return ReturnInfo(None, None, False, desc)
+        
         return ReturnInfo(None, show_type, True, desc)
 
     if 'format-as' in ret_def:

--- a/typedargs/doc_parser.py
+++ b/typedargs/doc_parser.py
@@ -344,7 +344,7 @@ def parse_param(param, include_desc=False):
 def parse_return(return_line, include_desc=False):
     """Parse a single return statement declaration.
 
-    The valid types of return declarion are a Returns: section heading
+    The valid types of return declaration are a Returns: section heading
     followed a line that looks like:
     type [format-as formatter]: description
 
@@ -366,7 +366,7 @@ def parse_return(return_line, include_desc=False):
         show_type = show_type.strip()
 
         if show_type not in ('string', 'context'):
-            raise ValidationError("Unkown show-as formatting specifier", found=show_type, expected=['string', 'context'])
+            raise ValidationError("Unknown show-as formatting specifier", found=show_type, expected=['string', 'context'])
 
         if show_type == 'string':
             return ReturnInfo(None, str, True, desc)

--- a/typedargs/doc_parser.py
+++ b/typedargs/doc_parser.py
@@ -350,7 +350,7 @@ def parse_return(return_line, include_desc=False):
 
     OR
 
-    type [show-as (string | context)]: description sentence
+    type [show-as (context | string | formatter)]: description sentence
     """
 
     ret_def, _colon, desc = return_line.partition(':')
@@ -362,16 +362,11 @@ def parse_return(return_line, include_desc=False):
 
     if 'show-as' in ret_def:
         ret_type, _showas, show_type = ret_def.partition('show-as')
-        ret_type = ret_type.strip()
         show_type = show_type.strip()
 
-        if show_type not in ('string', 'context'):
-            raise ValidationError("Unknown show-as formatting specifier", found=show_type, expected=['string', 'context'])
-
-        if show_type == 'string':
-            return ReturnInfo(None, str, True, desc)
-
-        return ReturnInfo(None, None, False, desc)
+        if show_type == 'context':
+            return ReturnInfo(None, None, False, desc)
+        return ReturnInfo(None, show_type, True, desc)
 
     if 'format-as' in ret_def:
         ret_type, _showas, formatter = ret_def.partition('format-as')

--- a/typedargs/metadata.py
+++ b/typedargs/metadata.py
@@ -295,6 +295,7 @@ class AnnotatedMetadata: #pylint: disable=R0902; These instance variables are re
             formatter_name = 'format_{}'.format(self.return_info.formatter)
             if hasattr(value, formatter_name) and callable(getattr(value, formatter_name)):
                 formatter = getattr(value, formatter_name)
+
                 # Method format_<formatter> may require an argument or not require and just return a string.
                 # In case it is not we have to ignore a given argument and call the method
                 formatter = ignore_not_required_arg(formatter)

--- a/typedargs/metadata.py
+++ b/typedargs/metadata.py
@@ -2,11 +2,10 @@
 
 import inspect
 import sys
-from typedargs import typeinfo
+from typedargs import typeinfo, utils
 from .exceptions import TypeSystemError, ArgumentError, ValidationError, InternalError
 from .basic_structures import ParameterInfo, ReturnInfo
 from .doc_annotate import parse_docstring
-from .utils import _call_with_optional_arg
 
 
 class AnnotatedMetadata: #pylint: disable=R0902; These instance variables are required.
@@ -297,7 +296,7 @@ class AnnotatedMetadata: #pylint: disable=R0902; These instance variables are re
         if formatter is str:
             return str(value)
 
-        return _call_with_optional_arg(formatter, value)
+        return utils.call_with_optional_arg(formatter, value)
 
     def convert_positional_argument(self, index, arg_value):
         """Convert and validate a positional argument.

--- a/typedargs/utils.py
+++ b/typedargs/utils.py
@@ -1,4 +1,5 @@
 """Utility functions that are only used internally inside typedargs."""
+import inspect
 
 from .exceptions import ValidationError
 from .metadata import AnnotatedMetadata
@@ -56,6 +57,15 @@ def _parse_validators(valids):
         outvals.append((name, args))
 
     return outvals
+
+
+def _call_with_optional_arg(func, arg):
+    """If func takes an argument, return func, otherwise return wrapped func to ignore the argument."""
+
+    if inspect.signature(func).parameters:
+        return func(arg)
+
+    return func()
 
 
 def context_name(con):

--- a/typedargs/utils.py
+++ b/typedargs/utils.py
@@ -2,6 +2,7 @@
 import inspect
 
 from .exceptions import ValidationError
+from .metadata import AnnotatedMetadata
 
 
 class BasicContext(dict):
@@ -58,7 +59,7 @@ def _parse_validators(valids):
     return outvals
 
 
-def _call_with_optional_arg(func, arg):
+def call_with_optional_arg(func, arg):
     """If func takes an argument, return func, otherwise return wrapped func to ignore the argument."""
 
     if inspect.signature(func).parameters:
@@ -89,9 +90,6 @@ def find_all(container):
     Returns:
         dict: A dict with all of the found functions in it.
     """
-    # moved from top to avoid circular import
-    from .metadata import AnnotatedMetadata
-
     if isinstance(container, dict):
         names = container.keys()
     else:

--- a/typedargs/utils.py
+++ b/typedargs/utils.py
@@ -2,7 +2,6 @@
 import inspect
 
 from .exceptions import ValidationError
-from .metadata import AnnotatedMetadata
 
 
 class BasicContext(dict):
@@ -90,6 +89,8 @@ def find_all(container):
     Returns:
         dict: A dict with all of the found functions in it.
     """
+    # moved from top to avoid circular import
+    from .metadata import AnnotatedMetadata
 
     if isinstance(container, dict):
         names = container.keys()


### PR DESCRIPTION
With this PR `show-as <formatter>` annotation may accept some formatter name in addition to already supported 'context' and 'string'.

Let's take an example from issue #60 description
```
@docannotate
def annotated_function():
    """Do a thing.

        Returns:
            ComplexType show-as single_line: The complex return value object.
    """
```
Object returned by `annotated_function` will be inspected to find a method `format_single_line`. It would be called for getting string representation of an object.
Method `format_single_line` could be implemented as requiring argument or not requiring. See examples below:
```
    class ComplexType:

        @staticmethod
        def format_single_string(val):
            val = str(val)
            return val.replace('\n', ' ')

    class ComplexType:
        def __init__(self):
            self.val = 'foo\nbar'

        def format_single_string(self):
            return self.val.replace('\n', ' ')
```

If method `format_<formatter>` does not exist then ValidationError will be raised.

PR also contains a test to cover cases when:
- format_<formatter> method requires an argument
- format_<formatter> method does not accept argument
- format_<formatter> method not found
- we have `show-as string` annotation

Closes #60 