### PR TITLE
Support function type annotations

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,6 +4,7 @@
 
 - Fix docstrings parsing (Issues #47, #34) 
 - Extend docannotate `show-as` return annotation to support more options (Issue #60)
+- Add support of function type annotations in @docannotate
 
 ## 1.0.2
 

--- a/test/test_docannotate.py
+++ b/test/test_docannotate.py
@@ -304,6 +304,8 @@ def test_func_type_annotation(caplog):
     func_doc_types = _types_list(func_doc)
     func_mismatch_types = _types_list(func_mismatch)
 
+    assert func_ann_types == ['str', 'bool', 'str']
+
     # Type names should be the same for parsing func_doc docstring and func_ann type annotations
     assert func_ann_types == func_doc_types
 

--- a/test/test_docannotate.py
+++ b/test/test_docannotate.py
@@ -162,8 +162,8 @@ def test_parsed_doc():
     assert parsed2.short_desc == u'Do something.'
     assert parsed1.short_desc == u'Do something.'
 
-    assert parsed1.param_info == {u'param2': ParameterInfo(type_name=u'bool', validators=[], desc=u'The basic dict parameter'),
-                                  u'param1': ParameterInfo(type_name=u'integer', validators=[], desc=u'A basic parameter')}
+    assert parsed1.param_info == {u'param2': ParameterInfo(type_class=None, type_name=u'bool', validators=[], desc=u'The basic dict parameter'),
+                                  u'param1': ParameterInfo(type_class=None, type_name=u'integer', validators=[], desc=u'A basic parameter')}
 
 
 def test_return_value_formatter():

--- a/test/test_docannotate.py
+++ b/test/test_docannotate.py
@@ -249,3 +249,70 @@ def test_return_value_formatter_string():
 
     ret_value = func_string()
     assert func_string.metadata.format_returnvalue(ret_value) == 'foo\nbar'
+
+
+def test_func_type_annotation(caplog):
+    """Make sure we support python 3 function type annotations."""
+
+    @docannotate
+    def func_ann(param: str, flag: bool = True) -> str:
+        """A function with type annotations.
+        Args:
+            param: Description
+            flag: An optional flag
+
+        Returns:
+            Some result
+        """
+        return param
+
+    @docannotate
+    def func_doc(param, flag=True):
+        """A function with types specified in docstring.
+        Args:
+            param (str): Description
+            flag (bool): An optional flag
+
+        Returns:
+            str: Some result
+        """
+        return param
+
+    @docannotate
+    def func_mismatch(param: str, flag: bool = True) -> str:
+        """A function with type info mismatch between type annotations and docstring.
+        Args:
+            param (int): Description
+            flag (bool): An optional flag
+
+        Returns:
+            str: Some result
+        """
+        return param
+
+    # trigger docstring and type annotations parsing
+    _ = func_ann.metadata.returns_data()
+    _ = func_doc.metadata.returns_data()
+    _ = func_mismatch.metadata.returns_data()
+
+    def _types_list(f):
+        types = [info.type_name for info in f.metadata.annotated_params.values()]
+        types.append(f.metadata.return_info.type_name)
+        return types
+
+    func_ann_types = _types_list(func_ann)
+    func_doc_types = _types_list(func_doc)
+    func_mismatch_types = _types_list(func_mismatch)
+
+    # Type names should be the same for parsing func_doc docstring and func_ann type annotations
+    assert func_ann_types == func_doc_types
+
+    # Check warning message about type info mismatch, it should be only one there for func_mismatch
+    assert len(caplog.records) == 1
+    warn_record = caplog.records[0]
+    assert warn_record.levelname == 'WARNING'
+    assert 'Type info mismatch' in warn_record.message and "func_mismatch" in warn_record.message
+
+    # Type annotations for func_ann and func_mismatch are the same.
+    # Check if parsed info is the same regardless of wrong param type in func_mismatch docstring
+    assert func_ann_types == func_mismatch_types

--- a/test/test_docannotate.py
+++ b/test/test_docannotate.py
@@ -115,13 +115,13 @@ def test_return_parsing():
     """Make sure we can parse a show-as and format-as line."""
 
     _params, retinfo = parse_docstring(DOCSTRING_SHOWAS)
-    assert retinfo == (None, 'string', True, None)
+    assert retinfo == (None, None, 'string', True, None)
 
     _params, retinfo = parse_docstring(DOCSTRING_FORMATAS)
-    assert retinfo == ("integer", "hex", True, None)
+    assert retinfo == (None, "integer", "hex", True, None)
 
     _params, retinfo = parse_docstring(DOCSTRING_CONTEXT)
-    assert retinfo == (None, None, False, None)
+    assert retinfo == (None, None, None, False, None)
 
 
 DOCSTRING2 = """Do something.

--- a/test/test_docannotate.py
+++ b/test/test_docannotate.py
@@ -296,7 +296,7 @@ def test_func_type_annotation(caplog):
     _ = func_mismatch.metadata.returns_data()
 
     def _types_list(f):
-        types = [info.type_name for info in f.metadata.annotated_params.values()]
+        types = [info.type_name for param, info in sorted(f.metadata.annotated_params.items())]
         types.append(f.metadata.return_info.type_name)
         return types
 
@@ -304,7 +304,7 @@ def test_func_type_annotation(caplog):
     func_doc_types = _types_list(func_doc)
     func_mismatch_types = _types_list(func_mismatch)
 
-    assert func_ann_types == ['str', 'bool', 'str']
+    assert func_ann_types == ['bool', 'str', 'str']
 
     # Type names should be the same for parsing func_doc docstring and func_ann type annotations
     assert func_ann_types == func_doc_types

--- a/typedargs/annotate.py
+++ b/typedargs/annotate.py
@@ -127,7 +127,7 @@ def param(name, type_name, *validators, **kwargs):
         func = annotated(func)
 
         valids = _parse_validators(validators)
-        func.metadata.add_param(name, type_name, valids, **kwargs)
+        func.metadata.add_param(name, None, type_name, valids, **kwargs)
 
         # Only decorate the function once even if we have multiple param decorators
         if func.decorated:

--- a/typedargs/basic_structures.py
+++ b/typedargs/basic_structures.py
@@ -1,7 +1,40 @@
 """Basic structures used to describe parameters and return values."""
 
-from collections import namedtuple
+
+class ParameterInfo:
+
+    def __init__(self, type_class, type_name, validators, desc):
+        self.type_class = type_class
+        self.type_name = type_name
+        self.validators = validators
+        self.desc = desc
+
+    def __eq__(self, other):
+        return tuple(self) == other
+
+    def __iter__(self):
+        for prop in (self.type_class, self.type_name, self.validators, self.desc):
+            yield prop
+
+    def __str__(self):
+        return str(tuple(self))
 
 
-ParameterInfo = namedtuple("ParameterInfo", ['type_class', 'type_name', 'validators', 'desc'])
-ReturnInfo = namedtuple("ReturnInfo", ['type_class', 'type_name', 'formatter', 'is_data', 'desc'])
+class ReturnInfo:
+
+    def __init__(self, type_class, type_name, formatter, is_data, desc):
+        self.type_class = type_class
+        self.type_name = type_name
+        self.formatter = formatter
+        self.is_data = is_data
+        self.desc = desc
+
+    def __eq__(self, other):
+        return tuple(self) == other
+
+    def __iter__(self):
+        for prop in (self.type_class, self.type_name, self.formatter, self.is_data, self.desc):
+            yield prop
+
+    def __str__(self):
+        return str(tuple(self))

--- a/typedargs/basic_structures.py
+++ b/typedargs/basic_structures.py
@@ -3,5 +3,5 @@
 from collections import namedtuple
 
 
-ParameterInfo = namedtuple("ParameterInfo", ['type_name', 'validators', 'desc'])
-ReturnInfo = namedtuple("ReturnInfo", ['type_name', 'formatter', 'is_data', 'desc'])
+ParameterInfo = namedtuple("ParameterInfo", ['type_class', 'type_name', 'validators', 'desc'])
+ReturnInfo = namedtuple("ReturnInfo", ['type_class', 'type_name', 'formatter', 'is_data', 'desc'])

--- a/typedargs/doc_annotate.py
+++ b/typedargs/doc_annotate.py
@@ -4,8 +4,17 @@ import inspect
 from .doc_parser import parse_param, parse_return
 
 
-def parse_docstring(doc):
-    """Parse a docstring into ParameterInfo and ReturnInfo objects."""
+def parse_docstring(doc, validate_type=True):
+    """Parse a docstring into ParameterInfo and ReturnInfo objects.
+
+    Args:
+        doc (str): docstring to parse
+        validate_type (bool): True if ValidationError should be raised
+            where type is not specified for arg or return value.
+
+    Returns:
+        Tuple[Dict[str, ParameterInfo], Union[ReturnInfo, None]]: type information from passed docstring
+    """
 
     doc = inspect.cleandoc(doc)
     lines = doc.split('\n')
@@ -47,9 +56,9 @@ def parse_docstring(doc):
             # These are all the param lines in the docstring that are
             # not continuations of the previous line
             if section == 'args':
-                param_name, type_info = parse_param(stripped)
+                param_name, type_info = parse_param(stripped, validate_type=validate_type)
                 params[param_name] = type_info
             elif section == 'return':
-                returns = parse_return(stripped)
+                returns = parse_return(stripped, validate_type=validate_type)
 
     return params, returns

--- a/typedargs/doc_parser.py
+++ b/typedargs/doc_parser.py
@@ -338,7 +338,7 @@ def parse_param(param, include_desc=False):
         raise ValidationError("Invalid parameter type string not enclosed in ( ) characters", param_string=param_def, type_string=param_type)
 
     param_type = param_type[1:-1]
-    return param_name, ParameterInfo(param_type, [], desc)
+    return param_name, ParameterInfo(None, param_type, [], desc)
 
 
 def parse_return(return_line, include_desc=False):
@@ -365,15 +365,15 @@ def parse_return(return_line, include_desc=False):
         show_type = show_type.strip()
 
         if show_type == 'context':
-            return ReturnInfo(None, None, False, desc)
-        
-        return ReturnInfo(None, show_type, True, desc)
+            return ReturnInfo(None, None, None, False, desc)
+
+        return ReturnInfo(None, None, show_type, True, desc)
 
     if 'format-as' in ret_def:
         ret_type, _showas, formatter = ret_def.partition('format-as')
         ret_type = ret_type.strip()
         formatter = formatter.strip()
 
-        return ReturnInfo(ret_type, formatter, True, desc)
+        return ReturnInfo(None, ret_type, formatter, True, desc)
 
-    return ReturnInfo(ret_def, None, True, desc)
+    return ReturnInfo(None, ret_def, None, True, desc)

--- a/typedargs/doc_parser.py
+++ b/typedargs/doc_parser.py
@@ -344,7 +344,7 @@ def parse_param(param, include_desc=False, validate_type=True):
     return param_name, ParameterInfo(None, param_type, [], desc)
 
 
-def parse_return(return_line, include_desc=False):
+def parse_return(return_line, include_desc=False, validate_type=True):
     """Parse a single return statement declaration.
 
     The valid types of return declaration are a Returns: section heading
@@ -358,12 +358,16 @@ def parse_return(return_line, include_desc=False):
 
     ret_def, _colon, desc = return_line.partition(':')
     if _colon == "":
-        raise ValidationError("Invalid return declaration in docstring, missing colon", declaration=ret_def)
+        if validate_type:
+            raise ValidationError("Invalid return declaration in docstring, missing colon", declaration=ret_def)
+
+        desc = ret_def
+        ret_def = None
 
     if not include_desc:
         desc = None
 
-    if 'show-as' in ret_def:
+    if ret_def and 'show-as' in ret_def:
         ret_type, _showas, show_type = ret_def.partition('show-as')
         show_type = show_type.strip()
 
@@ -372,7 +376,7 @@ def parse_return(return_line, include_desc=False):
 
         return ReturnInfo(None, None, show_type, True, desc)
 
-    if 'format-as' in ret_def:
+    if ret_def and 'format-as' in ret_def:
         ret_type, _showas, formatter = ret_def.partition('format-as')
         ret_type = ret_type.strip()
         formatter = formatter.strip()

--- a/typedargs/doc_parser.py
+++ b/typedargs/doc_parser.py
@@ -321,7 +321,7 @@ class ParsedDocstring:
         return out.getvalue()
 
 
-def parse_param(param, include_desc=False):
+def parse_param(param, include_desc=False, validate_type=True):
     """Parse a single typed parameter statement."""
 
     param_def, _colon, desc = param.partition(':')
@@ -335,7 +335,10 @@ def parse_param(param, include_desc=False):
 
     param_name, _space, param_type = param_def.partition(' ')
     if len(param_type) < 2 or param_type[0] != '(' or param_type[-1] != ')':
-        raise ValidationError("Invalid parameter type string not enclosed in ( ) characters", param_string=param_def, type_string=param_type)
+        if validate_type:
+            raise ValidationError("Invalid parameter type string not enclosed in ( ) characters", param_string=param_def, type_string=param_type)
+
+        return param_name, ParameterInfo(None, None, [], desc)
 
     param_type = param_type[1:-1]
     return param_name, ParameterInfo(None, param_type, [], desc)

--- a/typedargs/metadata.py
+++ b/typedargs/metadata.py
@@ -103,11 +103,12 @@ class AnnotatedMetadata: #pylint: disable=R0902; These instance variables are re
         req = [x for x in req_names if x not in kw_args]
         return len(req) <= len(pos_args)
 
-    def add_param(self, name, type_name, validators, desc=None):
+    def add_param(self, name, type_class, type_name, validators, desc=None):
         """Add type information for a parameter by name.
 
         Args:
             name (str): The name of the parameter we wish to annotate
+            type_class (type): Parameter type class
             type_name (str): The name of the parameter's type
             validators (list): A list of either strings or n tuples that each
                 specify a validator defined for type_name.  If a string is passed,
@@ -122,7 +123,7 @@ class AnnotatedMetadata: #pylint: disable=R0902; These instance variables are re
         if name not in self.arg_names and name != self.varargs and name != self.kwargs:
             raise TypeSystemError("Annotation specified for unknown parameter", param=name)
 
-        info = ParameterInfo(None, type_name, validators, desc)
+        info = ParameterInfo(type_class, type_name, validators, desc)
         self.annotated_params[name] = info
 
     def typed_returnvalue(self, type_name, formatter=None):

--- a/typedargs/metadata.py
+++ b/typedargs/metadata.py
@@ -63,7 +63,7 @@ class AnnotatedMetadata: #pylint: disable=R0902; These instance variables are re
             self.arg_names = []
             self.arg_defaults = []
 
-        self.return_info = ReturnInfo(None, None, False, None)
+        self.return_info = ReturnInfo(None, None, None, False, None)
 
         if name is None:
             name = func.__name__
@@ -122,7 +122,7 @@ class AnnotatedMetadata: #pylint: disable=R0902; These instance variables are re
         if name not in self.arg_names and name != self.varargs and name != self.kwargs:
             raise TypeSystemError("Annotation specified for unknown parameter", param=name)
 
-        info = ParameterInfo(type_name, validators, desc)
+        info = ParameterInfo(None, type_name, validators, desc)
         self.annotated_params[name] = info
 
     def typed_returnvalue(self, type_name, formatter=None):
@@ -133,11 +133,11 @@ class AnnotatedMetadata: #pylint: disable=R0902; These instance variables are re
             formatter (str): An optional name of a formatting function specified
                 for the type given in type_name.
         """
-        self.return_info = ReturnInfo(type_name, formatter, True, None)
+        self.return_info = ReturnInfo(None, type_name, formatter, True, None)
 
     def string_returnvalue(self):
         """Mark the return value as data that should be converted with str."""
-        self.return_info = ReturnInfo(None, str, True, None)
+        self.return_info = ReturnInfo(None, None, str, True, None)
 
     def custom_returnvalue(self, printer, desc=None):
         """Use a custom function to print the return value.
@@ -147,7 +147,7 @@ class AnnotatedMetadata: #pylint: disable=R0902; These instance variables are re
                 value and convert it to a string.
             desc (str): An optional description of the return value.
         """
-        self.return_info = ReturnInfo(None, printer, True, desc)
+        self.return_info = ReturnInfo(None, None, printer, True, desc)
 
     def has_varargs(self):
         """Check if this function supports variable arguments."""

--- a/typedargs/metadata.py
+++ b/typedargs/metadata.py
@@ -1,7 +1,7 @@
 """The basic class that is used to store metadata about a function."""
 
 import inspect
-import sys
+import logging
 from typedargs import typeinfo, utils
 from .exceptions import TypeSystemError, ArgumentError, ValidationError, InternalError
 from .basic_structures import ParameterInfo, ReturnInfo
@@ -20,6 +20,8 @@ class AnnotatedMetadata: #pylint: disable=R0902; These instance variables are re
     """
 
     def __init__(self, func, name=None):
+        self._logger = logging.getLogger(__name__)
+
         self.annotated_params = {}
         self._has_self = False
 

--- a/typedargs/metadata.py
+++ b/typedargs/metadata.py
@@ -42,11 +42,8 @@ class AnnotatedMetadata: #pylint: disable=R0902; These instance variables are re
         # If we are called to annotate a context, we won't necessarily
         # have any arguments
         try:
-            if sys.version_info.major >= 3:
-                spec = inspect.getfullargspec(func)
-                args, varargs, kwargs, defaults = spec[:4]
-            else:
-                args, varargs, kwargs, defaults = inspect.getargspec(func)  # pylint: disable=deprecated-method
+            spec = inspect.getfullargspec(func)
+            args, varargs, kwargs, defaults = spec[:4]
 
             # Skip self argument if this is a method function
             if len(args) > 0 and args[0] == 'self':

--- a/typedargs/metadata.py
+++ b/typedargs/metadata.py
@@ -395,7 +395,7 @@ class AnnotatedMetadata: #pylint: disable=R0902; These instance variables are re
         if kwargs is None:
             kwargs = {}
 
-        if self.varargs is not None or self.kwargs is not None:
+        if self.has_varargs() or self.has_kwargs():
             raise InternalError("check_spec cannot be called on a function that takes *args or **kwargs")
 
         missing = object()

--- a/typedargs/metadata.py
+++ b/typedargs/metadata.py
@@ -94,8 +94,13 @@ class AnnotatedMetadata: #pylint: disable=R0902; These instance variables are re
         elif type_info_doc:
             self._add_annotation_info(*type_info_doc)
 
-        # If type annotations and docstring types are specified then they should be the same.
-        # If they are not then show warning message.
+        self._check_type_info_mismatch(type_info_ann, type_info_doc)
+
+    def _check_type_info_mismatch(self, type_info_ann, type_info_doc):
+        """Check for type info mismatch in type annotations and docstring types.
+        If type annotations and docstring types are both specified then they should be the same.
+        If they are not then show a warning message.
+        """
         if type_info_ann and type_info_doc:
 
             # if there any type info in docstring.

--- a/typedargs/type_annotations_parser.py
+++ b/typedargs/type_annotations_parser.py
@@ -18,6 +18,6 @@ def parse_annotations(annotations: dict) -> Tuple[Dict[str, ParameterInfo], Retu
 
     for param_name, param_type in annotations.items():
         param_type_name = TypeSystem.get_type_name(param_type)
-        params.update({param_name: ParameterInfo(param_type, param_type_name, [], None)})
+        params[param_name] = ParameterInfo(param_type, param_type_name, [], None)
 
     return params, returns

--- a/typedargs/type_annotations_parser.py
+++ b/typedargs/type_annotations_parser.py
@@ -9,7 +9,7 @@ def parse_annotations(annotations: dict) -> Tuple[Dict[str, ParameterInfo], Retu
     """Get type info for params and return value from annotations dictionary"""
 
     params = {}
-    returns = ReturnInfo(None, None, None, None, None)
+    returns = ReturnInfo(None, None, None, False, None)
 
     if 'return' in annotations:
         ret_type = annotations.pop('return')

--- a/typedargs/type_annotations_parser.py
+++ b/typedargs/type_annotations_parser.py
@@ -1,9 +1,11 @@
 """Routines for extracting parameter and return information from an annotation."""
+
+from typing import Tuple, Dict
+from typedargs.typeinfo import TypeSystem
 from .basic_structures import ParameterInfo, ReturnInfo
-from .typeinfo import TypeSystem
 
 
-def parse_annotations(annotations: dict):
+def parse_annotations(annotations: dict) -> Tuple[Dict[str, ParameterInfo], ReturnInfo]:
     """Get type info for params and return value from annotations dictionary"""
 
     params = {}

--- a/typedargs/type_annotations_parser.py
+++ b/typedargs/type_annotations_parser.py
@@ -1,18 +1,21 @@
 """Routines for extracting parameter and return information from an annotation."""
 from .basic_structures import ParameterInfo, ReturnInfo
+from .typeinfo import TypeSystem
 
 
 def parse_annotations(annotations: dict):
     """Get type info for params and return value from annotations dictionary"""
 
     params = {}
-    returns = ReturnInfo(None, None, None, None)
+    returns = ReturnInfo(None, None, None, None, None)
 
     if 'return' in annotations:
         ret_type = annotations.pop('return')
-        returns = ReturnInfo(ret_type, None, True, None)
+        ret_type_name = TypeSystem.get_type_name(ret_type)
+        returns = ReturnInfo(ret_type, ret_type_name, None, True, None)
 
     for param_name, param_type in annotations.items():
-        params.update({param_name: ParameterInfo(param_type, [], None)})
+        param_type_name = TypeSystem.get_type_name(param_type)
+        params.update({param_name: ParameterInfo(param_type, param_type_name, [], None)})
 
     return params, returns

--- a/typedargs/type_annotations_parser.py
+++ b/typedargs/type_annotations_parser.py
@@ -1,0 +1,18 @@
+"""Routines for extracting parameter and return information from an annotation."""
+from .basic_structures import ParameterInfo, ReturnInfo
+
+
+def parse_annotations(annotations: dict):
+    """Get type info for params and return value from annotations dictionary"""
+
+    params = {}
+    returns = ReturnInfo(None, None, None, None)
+
+    if 'return' in annotations:
+        ret_type = annotations.pop('return')
+        returns = ReturnInfo(ret_type, None, True, None)
+
+    for param_name, param_type in annotations.items():
+        params.update({param_name: ParameterInfo(param_type, [], None)})
+
+    return params, returns

--- a/typedargs/type_annotations_parser.py
+++ b/typedargs/type_annotations_parser.py
@@ -1,4 +1,4 @@
-"""Routines for extracting parameter and return information from an annotation."""
+"""Routines for extracting parameter and return information from type annotations."""
 
 from typing import Tuple, Dict
 from typedargs.typeinfo import TypeSystem

--- a/typedargs/typeinfo.py
+++ b/typedargs/typeinfo.py
@@ -17,7 +17,7 @@ import os.path
 import importlib
 import logging
 import typing
-from typing import Union
+from typing import Optional
 
 import sys
 from typedargs.exceptions import ValidationError, ArgumentError, KeyValueException
@@ -237,8 +237,8 @@ class TypeSystem:
 
         return False
 
-    @staticmethod
-    def get_type_name(type_class: type) -> Union[str, None]:
+    @classmethod
+    def get_type_name(cls, type_class: type) -> Optional[str]:
 
         type_name = None
 

--- a/typedargs/typeinfo.py
+++ b/typedargs/typeinfo.py
@@ -246,7 +246,7 @@ class TypeSystem:
 
         if inspect.getmodule(type_class) == typing:
 
-            # get 'type' from "typing.Type[sub, sub] or from typing.Type"
+            # get 'Type' from "typing.Type[sub, sub] or from typing.Type"
             type_name = str(type_class).split('.', 1)[-1].split('[')[0]
 
             if type_name in supported_typing_types:

--- a/typedargs/typeinfo.py
+++ b/typedargs/typeinfo.py
@@ -17,6 +17,7 @@ import os.path
 import importlib
 import logging
 import typing
+from typing import Union
 
 import sys
 from typedargs.exceptions import ValidationError, ArgumentError, KeyValueException
@@ -237,7 +238,7 @@ class TypeSystem:
         return False
 
     @staticmethod
-    def get_type_name(type_class):
+    def get_type_name(type_class: type) -> Union[str, None]:
 
         type_name = None
 

--- a/typedargs/typeinfo.py
+++ b/typedargs/typeinfo.py
@@ -12,11 +12,12 @@
 # Basic routines for converting information from string or other binary
 # formats to python types and for displaying those types in supported
 # formats
-
-
+import inspect
 import os.path
 import importlib
 import logging
+import typing
+
 import sys
 from typedargs.exceptions import ValidationError, ArgumentError, KeyValueException
 from typedargs import types
@@ -234,6 +235,26 @@ class TypeSystem:
             return True
 
         return False
+
+    @staticmethod
+    def get_type_name(type_class):
+
+        type_name = None
+
+        supported_typing_types = ('Dict', 'Tuple', 'List')
+
+        if inspect.getmodule(type_class) == typing:
+
+            # get 'type' from "typing.Type[sub, sub] or from typing.Type"
+            type_name = str(type_class).split('.', 1)[-1].split('[')[0]
+
+            if type_name in supported_typing_types:
+                type_name = type_name.lower()
+
+        elif hasattr(type_class, '__name__'):
+            type_name = type_class.__name__
+
+        return type_name
 
     def get_type(self, type_name):
         """Return the type object corresponding to a type name.


### PR DESCRIPTION
This PR adds support of python 3 type annotations.
- with applying `@docannotate` decorator type information would be parsed from function docstring and from type annotations if specified.
- if function has any type annotation (at least for one arg or return value) then docstring type info would be ignored. But if docstring includes return value formatter (like `show-as formatter`) then formatter name would be kept from docstring. Same behavior is supposed to be for param validators when issue #65 would be solved.
- currently (with master branch) if type is not specified for some param or return value in docstring then it raises ValidationError. With changes in this PR if function has type annotation then type info in docstring will not be validated. We can have docstring like in this example:
```
    @docannotate
    def func_ann(param: str, flag: bool = True) -> str:
        """A function with type annotations.
        Args:
            param: Description
            flag: An optional flag

        Returns:
            Some result
        """
        return param
```
- if function has type annotations and docstring types and there is a type mismatch for some param or return value then warning message would be printed

Also added a test to
- check parsing of type info from type annotations
- make sure that parsing of docstring types and type annotations results in the same types info when type info is the same in both places. For example:
```
def func_ann(param: str, flag: bool = True) -> str: ...

and

@docannotate
def func_doc(param, flag=True):
    """A function with types specified in docstring.
    Args:
        param (str): Description
        flag (bool): An optional flag

    Returns:
        str: Some result
    """
    return param
```
- make sure that warning message is printed in case of differences in type info from docstring and from annotations. And to make sure that annotations info wins.
 
For type annotations we can use builtin `typing` module. There is a big number of types. But with this PR I have added a support only for 'Dict', 'Tuple' and 'List'. Because these are represented in `typedargs.types`. That types are translated to builtin dict, tuple, list.  And if we specify any other type class from `typing` module, for example `def f() -> Union[str, int]: ...` for return value then this type would be ignored on parsing. 
If there any case where we have to support some other types from `typing` then I should extend `typedargs.types` to support them. But I'm not sure if we need it at this time.

Guys, please check the code changes. I would appreciate any remarks or suggestions.

Closes #59 