### PR TITLE
Support using docannotate on classes

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,7 +4,8 @@
 
 - Fix docstrings parsing (Issues #47, #34) 
 - Extend docannotate `show-as` return annotation to support more options (Issue #60)
-- Add support of function type annotations in @docannotate
+- Add support of function type annotations in `@docannotate`
+- Support using `@docannotate` on classes to annotate their `__init__()` functons
 
 ## 1.0.2
 

--- a/test/test_docannotate.py
+++ b/test/test_docannotate.py
@@ -392,3 +392,25 @@ def test_class_docstring_and_annotations(caplog):
     assert warn_record.levelname == 'WARNING'
     assert 'Type info mismatch' in warn_record.message and "Demo.__init__" in warn_record.message
 
+
+def test_docannotate_class_init():
+    """Make sure we can use @docannotate on class __init__() method.
+
+    In this case, the docstring should be ignored in favor of type annotations.
+    """
+
+    @context("Demo")
+    class Demo:
+
+        @docannotate
+        def __init__(self, arg):
+            """
+            Args:
+                arg (str): description
+            """
+
+    # trigger type info parsing
+    Demo.__init__.metadata.returns_data()
+
+    assert 'arg' in Demo.__init__.metadata.annotated_params
+    assert Demo.__init__.metadata.annotated_params['arg'].type_name == 'str'

--- a/test/test_docannotate.py
+++ b/test/test_docannotate.py
@@ -320,10 +320,28 @@ def test_func_type_annotation(caplog):
     assert func_ann_types == func_mismatch_types
 
 
-def test_class_docstring_basic():
+def test_class_docannotate_no_doc():
+    """Make sure we can use @docannotate on class without docstring.
+    Type annotations should be used to annotate __init__() method.
+    """
+
+    @context("Demo")
+    @docannotate
+    class Demo:
+        def __init__(self, arg: str):
+            pass
+
+    # trigger type info parsing
+    Demo.__init__.metadata.returns_data()
+
+    assert 'arg' in Demo.__init__.metadata.annotated_params
+    assert Demo.__init__.metadata.annotated_params['arg'].type_class == str
+
+
+def test_class_docannotate_2_docstrings():
     """Make sure we can decorate a class with @docannotate to annotate its __init__() method.
 
-    In this case the class docstring should be used and the __init__ docstring should be ignored.
+    If both docstrings exist then class docstring should be used and the __init__ docstring should be ignored.
     """
 
     @context("Demo")
@@ -348,7 +366,7 @@ def test_class_docstring_basic():
 
 
 def test_class_docstring_and_annotations():
-    """Make sure type annotations wins.
+    """Make sure type annotations wins if we decorate a class with @docannotate.
 
     In this case, the docstring should be ignored in favor of type annotations.
     """
@@ -365,4 +383,5 @@ def test_class_docstring_and_annotations():
     # trigger type info parsing
     Demo.__init__.metadata.returns_data()
 
-    assert Demo.__init__.metadata.annotated_params['arg'].type_name == 'str'
+    assert Demo.__init__.metadata.annotated_params['arg'].type_class == str
+

--- a/test/test_docannotate.py
+++ b/test/test_docannotate.py
@@ -365,7 +365,7 @@ def test_class_docannotate_2_docstrings():
     assert Demo.__init__.metadata.annotated_params['arg'].type_name == 'str'
 
 
-def test_class_docstring_and_annotations():
+def test_class_docstring_and_annotations(caplog):
     """Make sure type annotations wins if we decorate a class with @docannotate.
 
     In this case, the docstring should be ignored in favor of type annotations.
@@ -384,4 +384,10 @@ def test_class_docstring_and_annotations():
     Demo.__init__.metadata.returns_data()
 
     assert Demo.__init__.metadata.annotated_params['arg'].type_class == str
+
+    # Check warning message about type info mismatch, it should be only one there for "Demo.__init__"
+    assert len(caplog.records) == 1
+    warn_record = caplog.records[0]
+    assert warn_record.levelname == 'WARNING'
+    assert 'Type info mismatch' in warn_record.message and "Demo.__init__" in warn_record.message
 

--- a/test/test_docannotate.py
+++ b/test/test_docannotate.py
@@ -322,6 +322,7 @@ def test_func_type_annotation(caplog):
 
 def test_class_docannotate_no_doc():
     """Make sure we can use @docannotate on class without docstring.
+
     Type annotations should be used to annotate __init__() method.
     """
 
@@ -339,9 +340,9 @@ def test_class_docannotate_no_doc():
 
 
 def test_class_docannotate_2_docstrings():
-    """Make sure we can decorate a class with @docannotate to annotate its __init__() method.
+    """Make __init__ method is annotated correctly when the class and its __init__ method has docstrings.
 
-    If both docstrings exist then class docstring should be used and the __init__ docstring should be ignored.
+    If both docstrings exist then class docstring should be used and __init__ docstring should be ignored.
     """
 
     @context("Demo")

--- a/test/test_docannotate.py
+++ b/test/test_docannotate.py
@@ -393,7 +393,7 @@ def test_class_docstring_and_annotations(caplog):
     assert 'Type info mismatch' in warn_record.message and "Demo.__init__" in warn_record.message
 
 
-def test_docannotate_class_init():
+def test_docannotate_class_init(caplog):
     """Make sure we can use @docannotate on class __init__() method.
 
     In this case, the docstring should be ignored in favor of type annotations.
@@ -409,8 +409,19 @@ def test_docannotate_class_init():
                 arg (str): description
             """
 
+    @context("DemoAnn")
+    class DemoAnn:
+
+        @docannotate
+        def __init__(self, arg: str):
+            pass
+
     # trigger type info parsing
     Demo.__init__.metadata.returns_data()
+    DemoAnn.__init__.metadata.returns_data()
 
     assert 'arg' in Demo.__init__.metadata.annotated_params
+    assert 'arg' in DemoAnn.__init__.metadata.annotated_params
+
     assert Demo.__init__.metadata.annotated_params['arg'].type_name == 'str'
+    assert DemoAnn.__init__.metadata.annotated_params['arg'].type_class == str

--- a/test/test_docannotate.py
+++ b/test/test_docannotate.py
@@ -396,7 +396,7 @@ def test_class_docstring_and_annotations(caplog):
 def test_docannotate_class_init(caplog):
     """Make sure we can use @docannotate on class __init__() method.
 
-    In this case, the docstring should be ignored in favor of type annotations.
+    If method has a type annotations then docstring types should be ignored.
     """
 
     @context("Demo")

--- a/typedargs/annotate.py
+++ b/typedargs/annotate.py
@@ -247,7 +247,7 @@ def docannotate(func):
     if inspect.isclass(func):
         cls = func
         func = cls.__init__
-        func.class_docstring = cls.__doc__
+        func.class_docstring = cls.__doc__ if cls.__doc__ else ''
         func.class_name = cls.__name__
 
     func = annotated(func)

--- a/typedargs/metadata.py
+++ b/typedargs/metadata.py
@@ -115,7 +115,11 @@ class AnnotatedMetadata: #pylint: disable=R0902; These instance variables are re
                 doc_types = {'args': sorted(doc_arg_types), 'return': type_info_doc[1].type_name}
 
                 if ann_types != doc_types:
-                    self._logger.warning('Type info mismatch between type annotations and docstring in "%s"', self.name)
+                    if self._class_name:
+                        name = '{}.{}'.format(self._class_name, self.name)
+                    else:
+                        name = self.name
+                    self._logger.warning('Type info mismatch between docstring and type annotations in "%s"', name)
 
     def _add_annotation_info(self, params, return_info):
         """Add type information for params and return value of this function


### PR DESCRIPTION
This PR makes possible to use `@docannotate` on classes to decorate their `__init__()` method. For exmaple:
```
@context("MyClass")
@docannotate
class MyClass:
    """A manager for doing things.

        Args:
            arg1 (str): a thing
    """

    def __init__(self, arg1):
        pass
```
Priority of type info source for annotation is (from high to low):

    __init__() type annotations -> class docstring -> __init__() docstring

It means:
- if `__init__()` has a type annotations then docstrings would be skipped.
- if class docstring does not contain any parameters type info then it would be ignored, docstring of `__init__()` method would be used.

Also added a test to make sure we can use `@docannotate` on class `__init__()` method as well. Usage examples:
```
    @context("Demo")
    class Demo:

        @docannotate
        def __init__(self, arg):
            """
            Args:
                arg (str): description
            """

    @context("DemoAnn")
    class DemoAnn:

        @docannotate
        def __init__(self, arg: str):
            pass
```

Closes #63 
Closes #64