### PR TITLE
Support specifying validators in docstrings

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,6 +6,7 @@
 - Extend docannotate `show-as` return annotation to support more options (Issue #60)
 - Add support of function type annotations in `@docannotate`
 - Support using `@docannotate` on classes to annotate their `__init__()` functons
+- Support specifying validators in docstrings (Issue #65)
 
 ## 1.0.2
 

--- a/test/test_docannotate.py
+++ b/test/test_docannotate.py
@@ -453,3 +453,30 @@ def test_docstring_validators_parsing():
     assert arg2_validators == [('validate_list', [['a', 'b']])]
     assert arg3_validators == [('validate_valid', [None, True, 0.5])]
     assert arg4_validators == []
+
+
+def test_docstring_validators_validation():
+    """Make sure we can parse validators from docstring"""
+
+    @docannotate
+    def func(arg1: int) -> int:
+        """
+        Args:
+            arg1: {positive, range(1, 5)} description
+        """
+        return arg1
+
+    # trigger type info parsing
+    _ = func.metadata.returns_data()
+
+    assert func('1') == 1
+
+    # check "positive" validator
+    with pytest.raises(ValidationError):
+        func('-1')
+
+    # check "range" validator
+    with pytest.raises(ValidationError):
+        func('10')
+
+

--- a/test/test_docannotate.py
+++ b/test/test_docannotate.py
@@ -9,6 +9,7 @@ from typedargs.exceptions import ValidationError, ArgumentError
 from typedargs.doc_annotate import parse_docstring
 from typedargs.doc_parser import ParsedDocstring
 from typedargs.basic_structures import ParameterInfo
+from typing import Any
 
 
 DOCSTRING1 = """Do something.
@@ -425,3 +426,30 @@ def test_docannotate_class_init(caplog):
 
     assert Demo.__init__.metadata.annotated_params['arg'].type_name == 'str'
     assert DemoAnn.__init__.metadata.annotated_params['arg'].type_class == str
+
+
+def test_docstring_validators():
+    """Make sure we can parse validators from docstring"""
+
+    @docannotate
+    def func(arg1: int, arg2: str, arg3: Any, arg4: bool):
+        """
+        Args:
+            arg1: {positive, range(1, 5)} description
+            arg2: {list('a', 'b')} description
+            arg3: {valid(None, True, 0.5)}
+            arg4: descriptiom
+        """
+
+    # trigger type info parsing
+    _ = func.metadata.returns_data()
+
+    arg1_validators = func.metadata.annotated_params['arg1'].validators
+    arg2_validators = func.metadata.annotated_params['arg2'].validators
+    arg3_validators = func.metadata.annotated_params['arg3'].validators
+    arg4_validators = func.metadata.annotated_params['arg4'].validators
+
+    assert arg1_validators == [('validate_positive', []), ('validate_range', [1, 5])]
+    assert arg2_validators == [('validate_list', ['a', 'b'])]
+    assert arg3_validators == [('validate_valid', [None, True, 0.5])]
+    assert arg4_validators == []

--- a/test/test_docannotate.py
+++ b/test/test_docannotate.py
@@ -428,7 +428,7 @@ def test_docannotate_class_init(caplog):
     assert DemoAnn.__init__.metadata.annotated_params['arg'].type_class == str
 
 
-def test_docstring_validators():
+def test_docstring_validators_parsing():
     """Make sure we can parse validators from docstring"""
 
     @docannotate
@@ -436,7 +436,7 @@ def test_docstring_validators():
         """
         Args:
             arg1: {positive, range(1, 5)} description
-            arg2: {list('a', 'b')} description
+            arg2: {list(['a', 'b'])} description
             arg3: {valid(None, True, 0.5)}
             arg4: descriptiom
         """
@@ -450,6 +450,6 @@ def test_docstring_validators():
     arg4_validators = func.metadata.annotated_params['arg4'].validators
 
     assert arg1_validators == [('validate_positive', []), ('validate_range', [1, 5])]
-    assert arg2_validators == [('validate_list', ['a', 'b'])]
+    assert arg2_validators == [('validate_list', [['a', 'b']])]
     assert arg3_validators == [('validate_valid', [None, True, 0.5])]
     assert arg4_validators == []

--- a/typedargs/basic_structures.py
+++ b/typedargs/basic_structures.py
@@ -27,7 +27,8 @@ class ParameterInfo:
         return str(tuple(self))
 
     def __repr__(self):
-        return '<{}.{} id={} {}>'.format(self.__module__, self.__class__.__name__, id(self), str(tuple(self)))
+        return '<{} type_class={}, type_name={}, validators={}, desc={}>' \
+               ''.format(self.__class__.__name__, self.type_class, self.type_name, self.validators, self.desc)
 
 
 class ReturnInfo:
@@ -58,4 +59,5 @@ class ReturnInfo:
         return str(tuple(self))
 
     def __repr__(self):
-        return '<{}.{} id={} {}>'.format(self.__module__, self.__class__.__name__, id(self), str(tuple(self)))
+        return '<{} type_class={}, type_name={}, formatter={}, is_data={}, desc={}>'.format(
+            self.__class__.__name__, self.type_class, self.type_name, self.formatter, self.is_data, self.desc)

--- a/typedargs/basic_structures.py
+++ b/typedargs/basic_structures.py
@@ -4,6 +4,13 @@
 class ParameterInfo:
 
     def __init__(self, type_class, type_name, validators, desc):
+        """
+        Args:
+            type_class (Optional[type]): class of parameter value type
+            type_name (Optional[str]): parameter type name
+            validators (Optional[list]): list of validators
+            desc (Optional[str]): parameter description
+        """
         self.type_class = type_class
         self.type_name = type_name
         self.validators = validators
@@ -19,10 +26,21 @@ class ParameterInfo:
     def __str__(self):
         return str(tuple(self))
 
+    def __repr__(self):
+        return '<{}.{} id={} {}>'.format(self.__module__, self.__class__.__name__, id(self), str(tuple(self)))
+
 
 class ReturnInfo:
 
     def __init__(self, type_class, type_name, formatter, is_data, desc):
+        """
+        Args:
+            type_class (Optional[type]): class of parameter value type
+            type_name (Optional[str]): parameter type name
+            formatter (Optional[str]): parameter string formatter name
+            is_data (Optional[bool]): True if annotated function returns any data
+            desc (Optional[str]): parameter description
+        """
         self.type_class = type_class
         self.type_name = type_name
         self.formatter = formatter
@@ -38,3 +56,6 @@ class ReturnInfo:
 
     def __str__(self):
         return str(tuple(self))
+
+    def __repr__(self):
+        return '<{}.{} id={} {}>'.format(self.__module__, self.__class__.__name__, id(self), str(tuple(self)))

--- a/typedargs/basic_structures.py
+++ b/typedargs/basic_structures.py
@@ -1,16 +1,17 @@
 """Basic structures used to describe parameters and return values."""
+from typing import Optional
 
 
 class ParameterInfo:
+    """
+    Args:
+        type_class: class of parameter value type
+        type_name: parameter type name
+        validators: list of validators
+        desc: parameter description
+    """
+    def __init__(self, type_class: Optional[type], type_name: Optional[str], validators: Optional[list], desc: Optional[str]):
 
-    def __init__(self, type_class, type_name, validators, desc):
-        """
-        Args:
-            type_class (Optional[type]): class of parameter value type
-            type_name (Optional[str]): parameter type name
-            validators (Optional[list]): list of validators
-            desc (Optional[str]): parameter description
-        """
         self.type_class = type_class
         self.type_name = type_name
         self.validators = validators
@@ -32,16 +33,16 @@ class ParameterInfo:
 
 
 class ReturnInfo:
+    """
+    Args:
+        type_class: class of parameter value type
+        type_name: parameter type name
+        formatter: parameter string formatter name
+        is_data: True if annotated function returns any data
+        desc: parameter description
+    """
+    def __init__(self, type_class: Optional[type], type_name: Optional[str], formatter: Optional[str], is_data: Optional[bool], desc: Optional[str]):
 
-    def __init__(self, type_class, type_name, formatter, is_data, desc):
-        """
-        Args:
-            type_class (Optional[type]): class of parameter value type
-            type_name (Optional[str]): parameter type name
-            formatter (Optional[str]): parameter string formatter name
-            is_data (Optional[bool]): True if annotated function returns any data
-            desc (Optional[str]): parameter description
-        """
         self.type_class = type_class
         self.type_name = type_name
         self.formatter = formatter

--- a/typedargs/doc_parser.py
+++ b/typedargs/doc_parser.py
@@ -3,10 +3,12 @@ import ast
 import inspect
 from io import StringIO
 from collections import namedtuple
+from typing import List, Tuple
 from textwrap import fill, dedent
 from .basic_structures import ParameterInfo, ReturnInfo
 from .exceptions import ValidationError
 from .terminal import get_terminal_size
+
 
 
 BlankLine = namedtuple("BlankLine", ['contents'])
@@ -321,7 +323,7 @@ class ParsedDocstring:
         return out.getvalue()
 
 
-def _parse_param_validators(param_desc):
+def _parse_param_validators(param_desc: str) -> List[Tuple[str, list]]:
     """Get validators from parameter description.
 
     Validators should be specified in braces. Arguments of validator should be in brackets.
@@ -333,10 +335,10 @@ def _parse_param_validators(param_desc):
     Allowed validator argument types are: str, int, bool, float, None, list
 
     Args:
-        param_desc (str): parameter description
+        param_desc: parameter description
 
     Returns:
-          List[Tuple[str, list]]: list of validators
+          list of validators
     """
 
     param_desc = param_desc.strip()

--- a/typedargs/doc_parser.py
+++ b/typedargs/doc_parser.py
@@ -389,10 +389,15 @@ def parse_param(param, include_desc=False, validate_type=True):
     """Parse a single typed parameter statement."""
 
     param_def, _colon, desc = param.partition(':')
+
+    validators = _parse_param_validators(desc)
+
     if not include_desc:
         desc = None
     else:
-        desc = desc.lstrip()
+        if validators:
+            desc = desc.split('}', 1)[1]
+        desc = desc.strip()
 
     if _colon == "":
         raise ValidationError("Invalid parameter declaration in docstring, missing colon", declaration=param)
@@ -402,10 +407,10 @@ def parse_param(param, include_desc=False, validate_type=True):
         if validate_type:
             raise ValidationError("Invalid parameter type string not enclosed in ( ) characters", param_string=param_def, type_string=param_type)
 
-        return param_name, ParameterInfo(None, None, [], desc)
+        return param_name, ParameterInfo(None, None, validators, desc)
 
     param_type = param_type[1:-1]
-    return param_name, ParameterInfo(None, param_type, [], desc)
+    return param_name, ParameterInfo(None, param_type, validators, desc)
 
 
 def parse_return(return_line, include_desc=False, validate_type=True):

--- a/typedargs/doc_parser.py
+++ b/typedargs/doc_parser.py
@@ -338,7 +338,7 @@ def _parse_param_validators(param_desc: str) -> List[Tuple[str, list]]:
         param_desc: parameter description
 
     Returns:
-          list of validators
+          A list of validators
     """
 
     param_desc = param_desc.strip()


### PR DESCRIPTION
This PR makes it possible to specify argument validators in docstring. 
Example:
```
    @docannotate
    def func(arg1: int, arg2: str, arg3: Any, arg4: bool):
        """
        Args:
            arg1: {positive, range(1, 5)} description
            arg2: {list('a', 'b')} description
            arg3: {valid(None, True, 0.5)}
            arg4: descriptiom
        """
```
These validators would be parsed accordingly to lists like `[(validator, [arg, ..]), ..]`:
```
    arg1 validators: [('validate_positive', []), ('validate_range', [1, 5])]
    arg2 validators: [('validate_list', ['a', 'b'])]
    arg3 validators: [('validate_valid', [None, True, 0.5])]
    arg4 validators: []
```
Notes:
- validator arguments in parenthesis should be a valid python code.
- allowed validator argument types are: str, int, bool, float, list, None

Place for validators notation is chosen to be after colon `:`. If we place validators before colon, near 
a type notation then Sphinx would try to recognize a validator name as a python type. For example:
```
arg (int) {range(1, 5)}: description
```
-- in generated html validator name "range" would be a link to python doc for builtin `range` function.

As for mentioned question in issue #65 description:

    how will the types of arguments for complex validators be processed. Will they be handed off as 
    strings to the underlying validate_* function or will there be some kind of docannotate functionality 
    on that function to infer the desired types and convert. I would recommend the latter if possible.

With restriction mentioned above (Notes paragraph) we do not need to use any docannotate functionality and do not need to make validators to accept only strings.
I do not see a case where we need to support something beyond of these restrictions. Such approach is also seems clear and unambiguous for user.
Please, let me know if you have any thoughts on this.

Closes #65 