### PR TITLE
Support type classes instead of type modules

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,6 +6,8 @@
 - Extend docannotate `show-as` return annotation to support more options (Issue #60)
 - Add support of function type annotations in `@docannotate`
 - Support using `@docannotate` on classes to annotate their `__init__()` functons
+- Support type classes in type annotations for converting argument from string 
+  and formatting return value  
 
 ## 1.0.2
 

--- a/test/test_docannotate.py
+++ b/test/test_docannotate.py
@@ -487,6 +487,14 @@ def test_custom_type_class():
     # check formatting return value
     assert func.metadata.format_returnvalue(ret_value) == '0x1'
 
+    # trying to format return value having wrong type should cause raising a ValidationError
+    with pytest.raises(ValidationError):
+        func.metadata.format_returnvalue(1)
+
+    # passing an argument having wrong type (and not string) should cause raising a ValidationError
+    with pytest.raises(ValidationError):
+        func(1)
+
 
 def test_docstring_validators_parsing():
     """Make sure we can parse validators from docstring"""

--- a/test/test_docannotate.py
+++ b/test/test_docannotate.py
@@ -425,3 +425,33 @@ def test_docannotate_class_init(caplog):
 
     assert Demo.__init__.metadata.annotated_params['arg'].type_name == 'str'
     assert DemoAnn.__init__.metadata.annotated_params['arg'].type_class == str
+
+
+def test_custom_type_class():
+
+    class DemoInteger:
+        @classmethod
+        def FromString(cls, arg):
+            return int(arg)
+
+        @classmethod
+        def format_hex(cls, arg):
+            return "0x%X" % arg
+
+    @docannotate
+    def func(arg: DemoInteger) -> DemoInteger:
+        """Basic function.
+
+        Args:
+            arg: The input that will be converted to DemoInteger
+
+        Returns:
+            DemoInteger show-as hex: Some description
+        """
+        return arg
+
+    # trigger type info parsing
+    func.metadata.returns_data()
+
+    assert func('1') == 1
+    assert func.metadata.format_returnvalue(1) == '0x1'

--- a/test/test_docannotate.py
+++ b/test/test_docannotate.py
@@ -428,6 +428,11 @@ def test_docannotate_class_init(caplog):
 
 
 def test_custom_type_class():
+    """Make sure we can annotate a function with type class.
+
+    @docannotate should use methods of this class to convert arguments from string,
+    to validate arguments and to format return value.
+    """
 
     class DemoInteger:
         @classmethod

--- a/test/test_docannotate.py
+++ b/test/test_docannotate.py
@@ -439,6 +439,9 @@ def test_custom_type_class():
         def __init__(self, value: int):
             self.value = value
 
+        def __eq__(self, other):
+            return self.__class__ == other.__class__ and self.value == other.value
+
         @classmethod
         def FromString(cls, arg):
             return cls(int(arg))
@@ -469,9 +472,11 @@ def test_custom_type_class():
 
     ret_value = func('1')
 
+    # Support of argument conversion from string should not break original function behaviour
+    assert func(DemoInteger(1)) == DemoInteger(1)
+
     # check converting from string
-    assert isinstance(ret_value, DemoInteger)
-    assert ret_value.value == 1
+    assert ret_value == DemoInteger(1)
 
     # check argument validation
     with pytest.raises(ValidationError) as exc:

--- a/typedargs/metadata.py
+++ b/typedargs/metadata.py
@@ -367,7 +367,7 @@ class AnnotatedMetadata: #pylint: disable=R0902; These instance variables are re
         # Otherwise convert this value to a string with formatter function
         validation_err = ValidationError('Cannot convert return value to string')
 
-        if self.return_info.formatter is None or self.return_info.formatter == 'string':
+        if self.return_info.formatter in (None, 'default', 'str', 'string'):
             formatter = str
         elif callable(self.return_info.formatter):
             formatter = self.return_info.formatter

--- a/typedargs/metadata.py
+++ b/typedargs/metadata.py
@@ -109,8 +109,8 @@ class AnnotatedMetadata: #pylint: disable=R0902; These instance variables are re
 
             # if there any type info in docstring.
             doc_return_type = getattr(type_info_doc[1], 'type_name', None)
-            if list(filter(lambda val: val.type_name, type_info_doc[0].values())) or doc_return_type:
-
+            doc_arg_types = list(filter(lambda val: val.type_name, type_info_doc[0].values()))
+            if doc_arg_types or doc_return_type:
                 # do not take docstring arg descriptions where type is not specified
                 doc_arg_types = [(arg, info.type_name) for arg, info in type_info_doc[0].items() if info.type_name is not None]
                 ann_arg_types = [(arg, info.type_name) for arg, info in type_info_ann[0].items()]

--- a/typedargs/metadata.py
+++ b/typedargs/metadata.py
@@ -480,7 +480,7 @@ class AnnotatedMetadata: #pylint: disable=R0902; These instance variables are re
         type_class = self.param_type_class(arg_name)
         type_name = self.param_type(arg_name)
 
-        if type_class is not None and hasattr(type_class, 'FromString'):
+        if type_class is not None and callable(getattr(type_class, 'FromString', None)):
             val = type_class.FromString(arg_value)
         else:
             if type_name is None:
@@ -492,20 +492,24 @@ class AnnotatedMetadata: #pylint: disable=R0902; These instance variables are re
         if len(validators) == 0:
             return val
 
-        if type_class:
-            type_obj = type_class
-        else:
-            type_obj = typeinfo.type_system.get_type(type_name)
+        type_obj = typeinfo.type_system.get_type(type_name) if type_name else None
 
         # Run all of the validators that were defined for this argument.
         # If the validation fails, they will raise an exception that we convert to
         # an instance of ValidationError
         try:
             for validator_name, extra_args in validators:
-                if not hasattr(type_obj, validator_name):
-                    raise ValidationError("Could not find validator specified for argument", argument=arg_name, validator_name=validator_name, type=str(type_obj), method=dir(type_obj))
+                obj_validator = getattr(type_obj, validator_name, None)
 
-                validator = getattr(type_obj, validator_name)
+                class_validator = getattr(type_class, validator_name, None)
+                if not callable(class_validator):
+                    class_validator = None
+
+                if not class_validator and not obj_validator:
+                    raise ValidationError("Could not find validator specified for argument",
+                                          argument=arg_name, validator_name=validator_name, type_class=type_class, type_obj=str(type_obj), method=dir(type_obj))
+
+                validator = class_validator if class_validator else obj_validator
                 validator(val, *extra_args)
         except (ValueError, TypeError) as exc:
             raise ValidationError(exc.args[0], argument=arg_name, arg_value=val)

--- a/typedargs/metadata.py
+++ b/typedargs/metadata.py
@@ -2,6 +2,7 @@
 
 import inspect
 import logging
+from typing import Union
 from typedargs import typeinfo, utils
 from .exceptions import TypeSystemError, ArgumentError, ValidationError, InternalError
 from .basic_structures import ParameterInfo, ReturnInfo
@@ -245,7 +246,7 @@ class AnnotatedMetadata: #pylint: disable=R0902; These instance variables are re
 
         return possible[0]
 
-    def param_type(self, name):
+    def param_type(self, name: str) -> Union[type, str, None]:
         """Get the parameter type information by name.
 
         Args:
@@ -260,24 +261,10 @@ class AnnotatedMetadata: #pylint: disable=R0902; These instance variables are re
         if name not in self.annotated_params:
             return None
 
+        if self.annotated_params[name].type_class:
+            return self.annotated_params[name].type_class
+
         return self.annotated_params[name].type_name
-
-    def param_type_class(self, name):
-        """Get the parameter type information by name.
-
-        Args:
-            name (str): The full name of a parameter.
-
-        Returns:
-            type: The type class or None if no type information is given.
-        """
-
-        self._ensure_loaded()
-
-        if name not in self.annotated_params:
-            return None
-
-        return self.annotated_params[name].type_class
 
     def signature(self, name=None):
         """Return our function signature as a string.

--- a/typedargs/metadata.py
+++ b/typedargs/metadata.py
@@ -325,6 +325,20 @@ class AnnotatedMetadata: #pylint: disable=R0902; These instance variables are re
 
         return "{}({})".format(name, ", ".join(args))
 
+    def _format_returnvalue_type_class(self, value):
+        if self.return_info.formatter in ('str', 'string', 'default', None):
+            default_formatter = getattr(self.return_info.type_class, 'format_default', None)
+            if callable(default_formatter):
+                return default_formatter(value)
+
+        elif self.return_info.formatter and isinstance(self.return_info.formatter, str):
+            formatter_name = 'format_{}'.format(self.return_info.formatter)
+            formatter = getattr(self.return_info.type_class, formatter_name, None)
+            if callable(formatter):
+                return formatter(value)
+
+        return None
+
     def format_returnvalue(self, value):
         """Format the return value of this function as a string.
 
@@ -341,8 +355,13 @@ class AnnotatedMetadata: #pylint: disable=R0902; These instance variables are re
         if not self.return_info.is_data:
             return None
 
-        # If the return value is typed, use the type_system to format it
-        if self.return_info.type_name is not None:
+        # If the return value is typed, use the type class or type_system to format it
+        if self.return_info.type_class:
+            result_str = self._format_returnvalue_type_class(value)
+            if result_str is not None:
+                return result_str
+
+        if not self.return_info.type_class and self.return_info.type_name:
             return typeinfo.type_system.format_value(value, self.return_info.type_name, self.return_info.formatter)
 
         # Otherwise convert this value to a string with formatter function

--- a/typedargs/type_annotations_parser.py
+++ b/typedargs/type_annotations_parser.py
@@ -11,6 +11,8 @@ def parse_annotations(annotations: dict) -> Tuple[Dict[str, ParameterInfo], Retu
     params = {}
     returns = ReturnInfo(None, None, None, False, None)
 
+    # todo: Remove ret_type_name after switching to type classes instead of type modules
+    # todo: But make sure that type mismatch warning is logged in occasion
     if 'return' in annotations:
         ret_type = annotations.pop('return')
         ret_type_name = TypeSystem.get_type_name(ret_type)

--- a/typedargs/type_annotations_parser.py
+++ b/typedargs/type_annotations_parser.py
@@ -1,7 +1,6 @@
 """Routines for extracting parameter and return information from type annotations."""
 
 from typing import Tuple, Dict
-from typedargs.typeinfo import TypeSystem
 from typedargs.basic_structures import ParameterInfo, ReturnInfo
 
 
@@ -11,15 +10,11 @@ def parse_annotations(annotations: dict) -> Tuple[Dict[str, ParameterInfo], Retu
     params = {}
     returns = ReturnInfo(None, None, None, False, None)
 
-    # todo: Remove ret_type_name after switching to type classes instead of type modules
-    # todo: But make sure that type mismatch warning is logged in occasion
     if 'return' in annotations:
         ret_type = annotations.pop('return')
-        ret_type_name = TypeSystem.get_type_name(ret_type)
-        returns = ReturnInfo(ret_type, ret_type_name, None, True, None)
+        returns = ReturnInfo(ret_type, None, None, True, None)
 
     for param_name, param_type in annotations.items():
-        param_type_name = TypeSystem.get_type_name(param_type)
-        params[param_name] = ParameterInfo(param_type, param_type_name, [], None)
+        params[param_name] = ParameterInfo(param_type, None, [], None)
 
     return params, returns

--- a/typedargs/type_annotations_parser.py
+++ b/typedargs/type_annotations_parser.py
@@ -1,7 +1,18 @@
 """Routines for extracting parameter and return information from type annotations."""
 
+import inspect
+import typing
 from typing import Tuple, Dict
 from typedargs.basic_structures import ParameterInfo, ReturnInfo
+
+
+def _get_type_name(type_class):
+    type_name = getattr(type_class, '__name__', None)
+
+    if inspect.getmodule(type_class) == typing and type_name in ('Dict', 'List', 'Tuple'):
+        type_name = type_name.lower()
+
+    return type_name
 
 
 def parse_annotations(annotations: dict) -> Tuple[Dict[str, ParameterInfo], ReturnInfo]:
@@ -12,9 +23,11 @@ def parse_annotations(annotations: dict) -> Tuple[Dict[str, ParameterInfo], Retu
 
     if 'return' in annotations:
         ret_type = annotations.pop('return')
-        returns = ReturnInfo(ret_type, None, None, True, None)
+        type_name = _get_type_name(ret_type)
+        returns = ReturnInfo(ret_type, type_name, None, True, None)
 
     for param_name, param_type in annotations.items():
-        params[param_name] = ParameterInfo(param_type, None, [], None)
+        type_name = _get_type_name(param_type)
+        params[param_name] = ParameterInfo(param_type, type_name, [], None)
 
     return params, returns

--- a/typedargs/type_annotations_parser.py
+++ b/typedargs/type_annotations_parser.py
@@ -2,7 +2,7 @@
 
 from typing import Tuple, Dict
 from typedargs.typeinfo import TypeSystem
-from .basic_structures import ParameterInfo, ReturnInfo
+from typedargs.basic_structures import ParameterInfo, ReturnInfo
 
 
 def parse_annotations(annotations: dict) -> Tuple[Dict[str, ParameterInfo], ReturnInfo]:

--- a/typedargs/type_annotations_parser.py
+++ b/typedargs/type_annotations_parser.py
@@ -22,11 +22,14 @@ def parse_annotations(annotations: dict) -> Tuple[Dict[str, ParameterInfo], Retu
     returns = ReturnInfo(None, None, None, False, None)
 
     if 'return' in annotations:
-        ret_type = annotations.pop('return')
+        ret_type = annotations['return']
         type_name = _get_type_name(ret_type)
         returns = ReturnInfo(ret_type, type_name, None, True, None)
 
     for param_name, param_type in annotations.items():
+        if param_name == 'return':
+            continue
+
         type_name = _get_type_name(param_type)
         params[param_name] = ParameterInfo(param_type, type_name, [], None)
 

--- a/typedargs/typeinfo.py
+++ b/typedargs/typeinfo.py
@@ -237,26 +237,6 @@ class TypeSystem:
 
         return False
 
-    @classmethod
-    def get_type_name(cls, type_class: type) -> Optional[str]:
-
-        type_name = None
-
-        supported_typing_types = ('Dict', 'Tuple', 'List')
-
-        if inspect.getmodule(type_class) == typing:
-
-            # get 'Type' from "typing.Type[sub, sub] or from typing.Type"
-            type_name = str(type_class).split('.', 1)[-1].split('[')[0]
-
-            if type_name in supported_typing_types:
-                type_name = type_name.lower()
-
-        elif hasattr(type_class, '__name__'):
-            type_name = type_class.__name__
-
-        return type_name
-
     def get_type(self, type_name):
         """Return the type object corresponding to a type name.
 

--- a/typedargs/typeinfo.py
+++ b/typedargs/typeinfo.py
@@ -39,6 +39,7 @@ class TypeSystem:
         self.interactive = False
         self.known_types = {}
         self.type_factories = {}
+        self.mapped_builtin_types = {}
         self.logger = logging.getLogger(__name__)
 
         for arg in args:
@@ -331,6 +332,9 @@ class TypeSystem:
         else:
             self._validate_type(typeobj)
             self.known_types[name] = typeobj
+
+            if hasattr(typeobj, 'MAPPED_BUILTIN_TYPE'):
+                self.mapped_builtin_types[typeobj.MAPPED_BUILTIN_TYPE] = typeobj
 
         if not hasattr(typeobj, "default_formatter"):
             raise ArgumentError("type is invalid, does not have default_formatter function", type=typeobj, methods=dir(typeobj))

--- a/typedargs/typeinfo.py
+++ b/typedargs/typeinfo.py
@@ -174,15 +174,13 @@ class TypeSystem:
         if not hasattr(typeobj, "default_formatter"):
             raise ArgumentError("type is invalid, does not have default_formatter function", type=typeobj, methods=dir(typeobj))
 
-    def is_known_type(self, type_name):
+    def is_known_type(self, type_or_name):
         """Check if type is known to the type system.
 
         Returns:
             bool: True if the type is a known instantiated simple type, False otherwise
         """
-
-        type_name = str(type_name)
-        if type_name in self.known_types:
+        if type_or_name in self.known_types or type_or_name in self.mapped_builtin_types:
             return True
 
         return False

--- a/typedargs/typeinfo.py
+++ b/typedargs/typeinfo.py
@@ -139,8 +139,8 @@ class TypeSystem:
         typed_val = self.convert_to_type(value, type, **kwargs)
         typeobj = self.get_type(type)
 
-        #Allow types to specify default formatting functions as 'default_formatter'
-        #otherwise if not format is specified, just convert the value to a string
+        # Allow types to specify default formatting functions as 'default_formatter'
+        # otherwise if no format is specified, just convert the value to a string
         if format is None:
             if hasattr(typeobj, 'default_formatter'):
                 format_func = getattr(typeobj, 'default_formatter')

--- a/typedargs/typeinfo.py
+++ b/typedargs/typeinfo.py
@@ -108,6 +108,8 @@ class TypeSystem:
                 conv = type_or_name.FromString(value)
                 return conv
 
+            raise ValidationError("Could not convert a value. Wrong value type.", type=type_or_name, value=value)
+
     def convert_from_binary(self, binvalue, type, **kwargs):
         """
         Convert binary data to type 'type'.

--- a/typedargs/typeinfo.py
+++ b/typedargs/typeinfo.py
@@ -236,15 +236,17 @@ class TypeSystem:
 
         return False
 
-    def get_type(self, type_name):
+    def get_type(self, type_or_name):
         """Return the type object corresponding to a type name.
 
         If type_name is not found, this triggers the loading of
         external types until a matching type is found or until there
         are no more external type sources.
         """
+        if type_or_name in self.mapped_builtin_types:
+            return self.mapped_builtin_types[type_or_name]
 
-        type_name = self._canonicalize_type(type_name)
+        type_name = self._canonicalize_type(type_or_name)
 
         # Add basic transformations on common abbreviations
         if str(type_name) == 'int':

--- a/typedargs/types/basic_dict.py
+++ b/typedargs/types/basic_dict.py
@@ -3,6 +3,9 @@
 import json
 
 
+MAPPED_BUILTIN_TYPE = dict
+
+
 def convert(arg, **kwargs):
     if arg is None:
         return None

--- a/typedargs/types/bool.py
+++ b/typedargs/types/bool.py
@@ -12,6 +12,9 @@
 # Simple boolean type
 
 
+MAPPED_BUILTIN_TYPE = bool
+
+
 def convert(arg, **kwargs):
     if arg is None:
         return arg

--- a/typedargs/types/bytes.py
+++ b/typedargs/types/bytes.py
@@ -10,6 +10,9 @@ import sys
 from binascii import unhexlify, hexlify
 
 
+MAPPED_BUILTIN_TYPE = bytes
+
+
 def convert(arg, **kwargs):
     if isinstance(arg, bytearray):
         return arg

--- a/typedargs/types/float.py
+++ b/typedargs/types/float.py
@@ -9,6 +9,9 @@
 # pylint: disable=unused-argument,missing-docstring
 
 
+MAPPED_BUILTIN_TYPE = float
+
+
 def convert(arg):
     if arg is None:
         return None

--- a/typedargs/types/integer.py
+++ b/typedargs/types/integer.py
@@ -11,6 +11,9 @@
 # integer type
 
 
+MAPPED_BUILTIN_TYPE = int
+
+
 def convert(arg):
     if arg is None:
         return None

--- a/typedargs/types/string.py
+++ b/typedargs/types/string.py
@@ -9,6 +9,9 @@
 # pylint: disable=unused-argument,missing-docstring
 
 
+MAPPED_BUILTIN_TYPE = str
+
+
 def convert(arg):
     if arg is None:
         return None


### PR DESCRIPTION
This PR makes possible to specify type class in annotations that has methods for converting argument value from string, validation, formatting return value. These methods would be used instead of type module.
Example:
```
    class DemoInteger:
        @classmethod
        def FromString(cls, arg):
            return int(arg)

        @classmethod
        def format_hex(cls, arg):
            return "0x%X" % arg

    @docannotate
    def func(arg: DemoInteger) -> DemoInteger:
        """Basic function.

        Args:
            arg: The input that will be converted to DemoInteger

        Returns:
            DemoInteger show-as hex: Some description
        """
        return arg
```
If the type class does not have required method (FromString() or validator or formatter) then type module would be used as it was before. Thus we still support annotating with Dict | List | Tuple  from typing module.

Added a test to check using type class for converting from string and for formatting. 
Type class validators could be tested after #78 PR would be merged

Closes #71 