### PR TITLE
Remove obsolete TypeSystem.convert_from_binary() method 

### DIFF
--- a/typedargs/types/bytes.py
+++ b/typedargs/types/bytes.py
@@ -3,13 +3,14 @@
 
 # pylint: disable=unused-argument,missing-docstring
 
-#bytes.py
-#Simple bytearray type
+# bytes.py
+# Simple bytearray type
 
-import sys
 from binascii import unhexlify, hexlify
 
+
 MAPPED_BUILTIN_TYPE = bytes
+
 
 def convert(arg, **kwargs):
     if isinstance(arg, bytearray):
@@ -25,10 +26,6 @@ def convert(arg, **kwargs):
         return arg
 
     raise TypeError("You must create a bytes object from bytes, bytearray or a hex string")
-
-
-def convert_binary(arg, **kwargs):
-    return bytearray(arg)
 
 
 def default_formatter(arg, **kwargs):


### PR DESCRIPTION
- removed `TypeSystem.convert_from_binary()`
- removed `TypeSystem.get_type_size()` method
- removed `convert_binary()` function from `bytes` type module

Couple of concerns:
- `TypeSystem.get_type_size()` is used in "old_momo_firmware" repository:
https://code.eng.archsys.io/search?q=get_type_size

-  `TypeSystem.convert_from_binary()` is used in repos "iotile-factory-companion", "iotile-shipping-companion":
https://code.eng.archsys.io/search?q=convert_from_binary

Do we have to support these packages? If we have to then this PR should be declined.


